### PR TITLE
promoted products triggering a purchase flow

### DIFF
--- a/IapExample/ios/IapExample.xcworkspace/contents.xcworkspacedata
+++ b/IapExample/ios/IapExample.xcworkspace/contents.xcworkspacedata
@@ -2,9 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:/Users/andres.aguilar/reactWorkspace/react-native-iap/RNIapIos.swift">
-   </FileRef>
-   <FileRef
       location = "group:IapExample.xcodeproj">
    </FileRef>
    <FileRef

--- a/README.md
+++ b/README.md
@@ -22,11 +22,9 @@ Published in [website](https://react-native-iap.dooboolab.com).
 
 This is a fork of https://github.com/dooboolab/react-native-iap. The binary is published to https://www.npmjs.com/package/@iap.dev/react-native-iap
 
-React Native IAP hook is out. You can see [medium post](https://medium.com/dooboolab/announcing-react-native-iap-hooks-96c7ffd3f19a) on how to use it.
+# Changes
 
-The `react-native-iap` module hasn't been maintained well recently. We are thinking of participating again and make the module healthier. Please refer to [2021 Maintenance plan](https://github.com/dooboolab/react-native-iap/issues/1241) and share with us how you or your organization is using it. Happy new year 🎉
-- The sample code is out in [Sponsor page](https://github.com/hyochan/dooboolab.com/blob/master/src/components/pages/Sponsor.tsx) in [dooboolab.com](https://github.com/hyochan/dooboolab.com) repository which sadly is rejected by Apple because of lacking product features. I will work on another example project to support this module. More information in [#1241 commment](https://github.com/dooboolab/react-native-iap/issues/1241#issuecomment-798540785).
-
+If you are implementing promoted products. Seee the updated FAQ
 ## Introduction
 
 This react-native module will help you access the In-app purchases capabilities of your phone on the `Android`, `iOS` platforms and the `Amazon` platform (Beta).

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -67,11 +67,29 @@
 
 ### How do I handle promoted products in iOS?
 - Offical doc is [here](https://developer.apple.com/app-store/promoting-in-app-purchases/).
-- No initial setup needed from `4.4.5`.
+Add the following to your `AppDelegate`. This will store the parameters and excecute the logic 
+```swift
+import UIKit
+import StoreKit
 
-Somewhere early in your app's lifecycle,
-call `initConnection` first (see above), then
-add a listener for the `iap-promoted-product` event:
+class AppDelegate: UIResponder, UIApplicationDelegate {
+                ....
+    // Attach an observer to the payment queue.
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+        SKPaymentQueue.default().add(RNIapQueue.shared)
+        return true
+    }
+
+    // Called when the application is about to terminate.
+    func applicationWillTerminate(_ application: UIApplication) {
+        // Remove the observer.
+        SKPaymentQueue.default().remove(RNIapQueue.shared)
+    }
+                ....
+}```
+
+
+Somewhere early in your app's lifecycle, add a listener for the `iap-promoted-product` event:
 
   ```javascript
   import { NativeModules, NativeEventEmitter } from 'react-native'
@@ -90,7 +108,7 @@ add a listener for the `iap-promoted-product` event:
     }
   });
   ```
-
+Then call  `initConnection` (see above)
 
 ### Using Face ID & Touch to checkout on iOS
 - After you have completed the setup and set your deployment target to `iOS 12`,

--- a/ios/RNIapIos.swift
+++ b/ios/RNIapIos.swift
@@ -128,6 +128,11 @@ class RNIapIos: RCTEventEmitter, SKRequestDelegate, SKPaymentTransactionObserver
         _ resolve: @escaping RCTPromiseResolveBlock = { _ in },
         reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
     ) {
+        SKPaymentQueue.default().remove(RNIapQueue.shared)
+        if let queue = RNIapQueue.shared.queue, let payment = RNIapQueue.shared.payment, let product = RNIapQueue.shared.product  {
+            let val = paymentQueue(queue, shouldAddStorePayment: payment,for: product)
+            print("Promoted product response \(val)")
+        }
         SKPaymentQueue.default().add(self)
         let canMakePayments = SKPaymentQueue.canMakePayments()
         resolve(NSNumber(value: canMakePayments))

--- a/ios/RNIapQueue.swift
+++ b/ios/RNIapQueue.swift
@@ -1,0 +1,35 @@
+//
+//  RNIapQueue.swift
+//  
+//
+//  Created by Andres Aguilar on 9/8/21.
+//
+
+import Foundation
+import StoreKit
+
+// Temporarily stores payment information since it is sent by the OS before RN instantiates the RNModule
+@objc(RNIapQueue)
+class RNIapQueue: NSObject, SKPaymentTransactionObserver {
+    func paymentQueue(_ queue: SKPaymentQueue, updatedTransactions transactions: [SKPaymentTransaction]) {
+        //No-op
+    }
+    
+    static let shared = RNIapQueue()
+    
+    var queue: SKPaymentQueue? = nil;
+    var payment: SKPayment? = nil;
+    var product: SKProduct? = nil;
+    
+    private override init(){}
+    
+    // Sent when a user initiates an IAP buy from the App Store
+    @available(iOS 11.0, *)
+    func paymentQueue(_ queue: SKPaymentQueue, shouldAddStorePayment payment: SKPayment, for product: SKProduct) -> Bool{
+        RNIapQueue.shared.queue = queue
+        RNIapQueue.shared.payment = payment
+        RNIapQueue.shared.product = product
+        return false
+    }
+    
+}


### PR DESCRIPTION
Fixes https://github.com/dooboolab/react-native-iap/issues/1398.

It differs from https://github.com/dooboolab/react-native-iap/pull/1467 in that the whole module doesn't have to be static, just the temporary Queue object