### PR TITLE
add missing android type

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -139,6 +139,7 @@ export interface Subscription extends ProductCommon {
   subscriptionPeriodNumberIOS?: string;
   subscriptionPeriodUnitIOS?: '' | 'YEAR' | 'MONTH' | 'WEEK' | 'DAY';
 
+  introductoryPriceAsAmountAndroid: string;
   introductoryPriceCyclesAndroid?: string;
   introductoryPricePeriodAndroid?: string;
   subscriptionPeriodAndroid?: string;


### PR DESCRIPTION
`introductoryPriceAsAmountAndroid` is set in java but not defined in types. This PR fixes it